### PR TITLE
🔧 Fix dockerManager module import error in Electron build

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,8 +103,7 @@
     },
     "files": [
       "dist/**/*",
-      "dist-electron/main.js",
-      "dist-electron/preload.js",
+      "dist-electron/**/*.js",
       "package.json"
     ],
     "mac": {


### PR DESCRIPTION
- Updated package.json build configuration to include all JS files from dist-electron
- Changed from explicitly listing main.js and preload.js to using wildcard pattern
- This ensures dockerManager.js is properly included in the packaged application
- Fixes "Cannot find module './dockerManager'" error when running the built app

🤖 Generated with [Claude Code](https://claude.ai/code)